### PR TITLE
Fixed the 400 Bad Request and Invaid URL

### DIFF
--- a/modes/antibot.py
+++ b/modes/antibot.py
@@ -4,8 +4,18 @@ from time import sleep
 
 
 def get_page_id(url, api):
+    headers = {
+        "accept": "application/json",
+        "apikey": f"{api}",
+    }
+    params = {
+        "url": f"{url}",
+        "apikey": f"{api}",
+    }
     page_id = requests.get(
-        f"https://antibotpedia.scrapinghub.com/api/check/add?url={url}&apikey={api}"
+        "https://antibotpedia.scrapinghub.com/api/check/add",
+        headers=headers,
+        params=params,
     )
     return page_id
 


### PR DESCRIPTION
When passed with this URL 'https://https//www.truepeoplesearch.com/resultaddress?streetaddress=20251%20S%20Lake%20Shore%20Blvd&citystatezip=Euclid,%20OH' we got 400 bad request and Invalid URL.
The validators.url(text) was returning True for this URL. Found out that the issue that I was not passing the URL in the params.
Because that is how the Antibotpedia API was expecting the URL to be passed, as I used a CURL to Requests convertor to see how it looks, then URL was passed in params so after passing the URL and API in the params with the headers. It got fixed.